### PR TITLE
- ugly hack to make android work

### DIFF
--- a/ouzel/graphics/opengl/RendererOGL.cpp
+++ b/ouzel/graphics/opengl/RendererOGL.cpp
@@ -77,6 +77,11 @@ namespace ouzel
 #ifdef GL_OES_mapbuffer
             mapBufferOES = (PFNGLMAPBUFFEROESPROC)eglGetProcAddress("glMapBufferOES");
             unmapBufferOES = (PFNGLUNMAPBUFFEROESPROC)eglGetProcAddress("glUnmapBufferOES");
+
+            // on Android this should be dynamically determined
+            // We set them to nil for compatiblity as an ugly hack
+            mapBufferOES        = NULL;
+            unmapBufferOES      = NULL;
 #endif
 
 #ifdef GL_EXT_map_buffer_range


### PR DESCRIPTION
On Android the availability for glMapBuffers () should be checked at runtime. At least on Google's nexus tablet the functions are not available.

The extension string looks like below.

````
GL_AMD_compressed_ATC_texture GL_AMD_performance_monitor GL_AMD_program_binary_Z400 GL_EXT_debug_label GL_EXT_debug_marker GL_EXT_discard_framebuffer GL_EXT_robustness GL_EXT_texture_format_BGRA8888 GL_EXT_texture_type_2_10_10_10_REV GL_NV_fence GL_OES_compressed_ETC1_RGB8_texture GL_OES_depth_texture GL_OES_depth24 GL_OES_EGL_image GL_OES_EGL_sync GL_OES_EGL_image_external GL_OES_element_index_uint GL_OES_fbo_render_mipmap GL_OES_fragment_precision_high GL_OES_get_program_binary GL_OES_packed_depth_stencil GL_OES_depth_texture_cube_map GL_OES_rgb8_rgba8 GL_OES_standard_derivatives GL_OES_texture_3D GL_OES_texture_float GL_OES_texture_half_float GL_OES_texture_half_float_linear GL_OES_texture_npot GL_OES_vertex_half_float GL_OES_vertex_type_10_10_10_2 GL_OES_vertex_array_object GL_QCOM_alpha_test GL_QCOM_binning_control GL_QCOM_driver_control GL_QCOM_perfmon_global_mode GL_QCOM_extended_get GL_QCOM_extended_get2 GL_QCOM_tiled_rendering GL_QCOM_writeonly_rendering GL_EXT_sRGB GL_EXT_sRGB_write_c
````

